### PR TITLE
Add simple hardware inventory CLI

### DIFF
--- a/src/hardware/__init__.py
+++ b/src/hardware/__init__.py
@@ -1,2 +1,16 @@
-def main() -> None:
-    print("Hello from hardware!")
+"""Entry point for the ``hardware`` command line tool."""
+
+from .inventory import cli as inventory_cli
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Dispatch command line arguments to the appropriate handler."""
+    parser = inventory_cli.build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "inventory":
+        inventory_cli.handle_inventory(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/src/hardware/inventory/cli.py
+++ b/src/hardware/inventory/cli.py
@@ -1,0 +1,60 @@
+"""Command line interface for the inventory subsystem."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from .config import InventoryConfig
+from .utils import generate_id, load_inventory, save_inventory
+
+
+# ---------------------------------------------------------------------------
+# parser construction
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hardware", description="Hardware utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    inv = sub.add_parser("inventory", help="Manage inventory records")
+    inv_sub = inv.add_subparsers(dest="action", required=True)
+
+    add_p = inv_sub.add_parser("add", help="Add an item")
+    add_p.add_argument("name")
+    add_p.add_argument("quantity", type=int)
+
+    inv_sub.add_parser("list", help="List items")
+
+    rm_p = inv_sub.add_parser("remove", help="Remove item by id")
+    rm_p.add_argument("id")
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# command handlers
+# ---------------------------------------------------------------------------
+
+def handle_inventory(args: argparse.Namespace) -> None:
+    cfg = InventoryConfig()
+    data = load_inventory(cfg.path)
+
+    if args.action == "add":
+        item = {"id": generate_id(), "name": args.name, "quantity": args.quantity}
+        data.append(item)
+        save_inventory(cfg.path, data)
+        print(f"Added {item['name']} with id {item['id']}")
+
+    elif args.action == "list":
+        for item in data:
+            print(f"{item['id']}: {item['name']} (x{item['quantity']})")
+
+    elif args.action == "remove":
+        new_data = [it for it in data if it.get("id") != args.id]
+        if len(new_data) != len(data):
+            save_inventory(cfg.path, new_data)
+            print(f"Removed item {args.id}")
+        else:
+            print(f"No item with id {args.id} found")
+

--- a/src/hardware/inventory/config.py
+++ b/src/hardware/inventory/config.py
@@ -1,0 +1,17 @@
+"""Configuration helpers for the inventory subsystem."""
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+
+@dataclass(slots=True)
+class InventoryConfig:
+    """Simple configuration object.
+
+    The path of the inventory database can be overridden via the
+    ``HARDWARE_DB_PATH`` environment variable. By default ``inventory.json``
+    in the current working directory is used.
+    """
+
+    path: Path = Path(os.getenv("HARDWARE_DB_PATH", "inventory.json"))

--- a/src/hardware/inventory/utils.py
+++ b/src/hardware/inventory/utils.py
@@ -1,0 +1,29 @@
+"""Utility helpers for manipulating the inventory database."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def load_inventory(path: Path) -> List[Dict[str, Any]]:
+    """Return the inventory list stored at *path*.
+
+    Missing files yield an empty list.
+    """
+    if path.exists():
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return []
+
+
+def save_inventory(path: Path, data: List[Dict[str, Any]]) -> None:
+    """Write *data* to *path* in JSON format."""
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def generate_id() -> str:
+    """Return a new unique identifier."""
+    return uuid.uuid4().hex


### PR DESCRIPTION
## Summary
- implement command dispatcher in `hardware.__init__`
- add an inventory CLI with add/list/remove commands
- include helpers for config and JSON persistence
- remove unused duplicate project directory

## Testing
- `pip install -e .`
- `hardware inventory add "widget" 3`
- `hardware inventory list`
- `hardware inventory remove <id>`


------
https://chatgpt.com/codex/tasks/task_e_6857d4066750832eb5be3992ffc74c6d