### PR TITLE
Add inventory utilities and unit tests

### DIFF
--- a/src/hardware/inventory/config.py
+++ b/src/hardware/inventory/config.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+
+def _load_toml(path: Path) -> dict:
+    if path.exists():
+        return tomllib.loads(path.read_text())
+    return {}
+
+
+def resolve_db_paths(db_sqlite: str | None = None, db_json: str | None = None,
+                     cwd: Path | None = None, home: Path | None = None) -> tuple[str | None, str | None]:
+    """Return (sqlite_path, json_path) with precedence:
+    CLI flags > cwd files > config files.
+    """
+    cwd = Path(cwd or Path.cwd())
+    home = Path(home or Path.home())
+
+    # CLI flags override everything
+    if db_sqlite or db_json:
+        return db_sqlite, db_json
+
+    # Check for files in cwd
+    sqlite_file = cwd / "metadata.db"
+    json_file = cwd / "components.jsonld"
+    if sqlite_file.exists() or json_file.exists():
+        return str(sqlite_file) if sqlite_file.exists() else None, \
+            str(json_file) if json_file.exists() else None
+
+    # Load configs
+    config = {}
+    # load global config first then override with cwd config
+    for path in (home / ".component_loader.toml", cwd / "cfg.toml"):
+        config.update(_load_toml(path))
+
+    db_cfg = config.get("database", {})
+    return db_cfg.get("sqlite_path"), db_cfg.get("jsonld_path")

--- a/src/hardware/inventory/utils.py
+++ b/src/hardware/inventory/utils.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import re
+import sqlite3
+from typing import Any
+
+import requests
+
+
+def ocr_extract(path: Path, service_url: str) -> str:
+    """Upload file to service_url and return extracted text."""
+    with path.open("rb") as fh:
+        resp = requests.post(service_url, files={"file": fh})
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("text") or data.get("ParsedResults", [{}])[0].get("ParsedText", "")
+
+
+def parse_fields(text: str) -> dict[str, Any]:
+    field_patterns = {
+        "value": r"([0-9\.]+\s*(?:[µu]F|nF|pF|kΩ|Ω|mH|uH|%))",
+        "qty": r"([0-9]+)\s*(?:pcs?)",
+        # price requires a currency symbol to avoid matching numeric values
+        "price": r"([€$£]\s*[0-9]+\.?[0-9]*)",
+    }
+    data: dict[str, Any] = {}
+    for key, pattern in field_patterns.items():
+        m = re.search(pattern, text, re.I)
+        if m:
+            data[key] = m.group(1).strip()
+    lines = text.splitlines()
+    data["description"] = lines[0][:120] if lines else ""
+    return data
+
+
+def text_hash(text: str) -> str:
+    return hashlib.sha1(text.encode()).hexdigest()
+
+
+class JSONDB:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        if path.exists():
+            self.entries = json.loads(path.read_text())
+        else:
+            self.entries = []
+
+    def has_file(self, f: str) -> bool:
+        return any(e.get("file") == f for e in self.entries)
+
+    def has_hash(self, h: str) -> bool:
+        return any(e.get("hash") == h for e in self.entries)
+
+    def add(self, entry: dict[str, Any], file: str, h: str) -> bool:
+        if self.has_file(file) or self.has_hash(h):
+            return False
+        entry = entry.copy()
+        entry["file"] = file
+        entry["hash"] = h
+        self.entries.append(entry)
+        self.path.write_text(json.dumps(self.entries))
+        return True
+
+
+class SQLiteDB:
+    def __init__(self, path: Path) -> None:
+        self.conn = sqlite3.connect(path)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS components (file TEXT, hash TEXT, data TEXT)"
+        )
+
+    def has_file(self, f: str) -> bool:
+        cur = self.conn.execute(
+            "SELECT 1 FROM components WHERE file = ? LIMIT 1", (f,)
+        )
+        return cur.fetchone() is not None
+
+    def has_hash(self, h: str) -> bool:
+        cur = self.conn.execute(
+            "SELECT 1 FROM components WHERE hash = ? LIMIT 1", (h,)
+        )
+        return cur.fetchone() is not None
+
+    def add(self, entry: dict[str, Any], file: str, h: str) -> bool:
+        if self.has_file(file) or self.has_hash(h):
+            return False
+        self.conn.execute(
+            "INSERT INTO components (file, hash, data) VALUES (?,?,?)",
+            (file, h, json.dumps(entry)),
+        )
+        self.conn.commit()
+        return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from hardware.inventory import config
+
+
+def test_resolve_db_paths_precedence(tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+
+    # global config
+    (home / ".component_loader.toml").write_text("""[database]
+sqlite_path = 'home.db'
+jsonld_path = 'home.json'
+""")
+    # cwd config
+    (cwd / "cfg.toml").write_text("""[database]
+sqlite_path = 'cwd.db'
+jsonld_path = 'cwd.json'
+""")
+
+    # CLI overrides all
+    s, j = config.resolve_db_paths("cli.db", "cli.json", cwd=cwd, home=home)
+    assert s == "cli.db" and j == "cli.json"
+
+    # CWD files override configs
+    (cwd / "metadata.db").touch()
+    (cwd / "components.jsonld").touch()
+    s, j = config.resolve_db_paths(None, None, cwd=cwd, home=home)
+    assert s == str(cwd / "metadata.db")
+    assert j == str(cwd / "components.jsonld")
+
+    # CWD config when no files
+    (cwd / "metadata.db").unlink()
+    (cwd / "components.jsonld").unlink()
+    s, j = config.resolve_db_paths(None, None, cwd=cwd, home=home)
+    assert s == "cwd.db" and j == "cwd.json"
+
+    # Global config fallback
+    (cwd / "cfg.toml").unlink()
+    s, j = config.resolve_db_paths(None, None, cwd=cwd, home=home)
+    assert s == "home.db" and j == "home.json"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,31 @@
+from hardware.inventory.utils import JSONDB, SQLiteDB
+
+
+def _run_backend_tests(db):
+    e1 = {"name": "c1"}
+    assert db.add(e1, "f1", "h1")
+    assert db.has_file("f1")
+    assert db.has_hash("h1")
+    # duplicate file/hash
+    assert not db.add(e1, "f1", "h1")
+    assert not db.add(e1, "f2", "h1")
+    # new entry
+    assert db.add({"name": "c2"}, "f2", "h2")
+
+
+def test_json_db(tmp_path):
+    path = tmp_path / "db.json"
+    db = JSONDB(path)
+    _run_backend_tests(db)
+    db2 = JSONDB(path)
+    assert db2.has_file("f1")
+    assert db2.has_hash("h2")
+
+
+def test_sqlite_db(tmp_path):
+    path = tmp_path / "db.sqlite"
+    db = SQLiteDB(path)
+    _run_backend_tests(db)
+    db2 = SQLiteDB(path)
+    assert db2.has_file("f1")
+    assert db2.has_hash("h2")

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from hardware.inventory.utils import ocr_extract, parse_fields, text_hash
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_ocr_extract_and_parse(monkeypatch, tmp_path):
+    img = tmp_path / "image.png"
+    img.write_bytes(b"x")
+
+    def fake_post(url, files):
+        return DummyResp({"ParsedResults": [{"ParsedText": "100uF 5 pcs $1.50"}]})
+
+    monkeypatch.setattr("requests.post", fake_post)
+    text = ocr_extract(img, "http://example.com")
+    assert "100uF" in text
+
+    data = parse_fields(text)
+    assert data["value"] == "100uF"
+    assert data["qty"] == "5"
+    assert data["price"] == "$1.50"
+
+    h = text_hash(text)
+    assert len(h) == 40


### PR DESCRIPTION
## Summary
- implement config resolution
- add OCR helpers and DB backends
- add pytest fixtures and unit tests for configs, OCR parsing, and DBs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d4056628832e94a87bfa86bae022